### PR TITLE
빌드 시 DB 접근 불가로 인한 빈 페이지 문제 해결

### DIFF
--- a/.github/actions/auto_deploy/action.yml
+++ b/.github/actions/auto_deploy/action.yml
@@ -34,37 +34,15 @@ runs:
         gcloud auth configure-docker ${{inputs.gcp_region}}-docker.pkg.dev
       shell: bash
 
-    - name: Create DB env file for Build
-      if: ${{ inputs.package == 'blog' }}
-      id: create_db_env
-      run: |
-        echo "DB_USER=$(gcloud secrets versions access latest --secret=db-user)" >> db_env
-        echo "DB_HOST=$(gcloud secrets versions access latest --secret=db-host)" >> db_env
-        echo "DB_NAME=$(gcloud secrets versions access latest --secret=db-name)" >> db_env
-        echo "DB_PASSWORD=$(gcloud secrets versions access latest --secret=db-password)" >> db_env
-        echo "DB_PORT=$(gcloud secrets versions access latest --secret=db-port)" >> db_env
-      shell: bash
-
     - name: Docker Build and Push Image
       id: docker_build_and_push_image
       run: |
         IMAGE_NAME="${{inputs.gcp_region}}-docker.pkg.dev/${{inputs.gcp_project_id}}/monorepo-${{inputs.package}}/deploy"
 
-        SECRET_ARGS=""
-        if [ "${{inputs.package}}" = "blog" ]; then
-          SECRET_ARGS="--secret id=db_env,src=db_env"
-        fi
-
-        DOCKER_BUILDKIT=1 docker build \
-          $SECRET_ARGS \
+        docker build \
           -t $IMAGE_NAME:latest -f apps/${{inputs.package}}/Dockerfile .
 
         docker push $IMAGE_NAME:latest
-      shell: bash
-
-    - name: Cleanup DB env file
-      if: ${{ inputs.package == 'blog' }}
-      run: rm -f db_env
       shell: bash
 
     - name: Deploy to Cloud Run (Blog)

--- a/apps/blog/Dockerfile
+++ b/apps/blog/Dockerfile
@@ -34,9 +34,7 @@ RUN npm install -g pnpm && \
 
 RUN pnpm install --frozen-lockfile
 
-RUN --mount=type=secret,id=db_env,target=/run/secrets/db_env \
-    set -a && . /run/secrets/db_env && set +a && \
-    turbo run build --filter=blog --no-daemon
+RUN turbo run build --filter=blog --no-daemon
 
 FROM node:22.14.0-alpine3.21 AS runner
 

--- a/apps/blog/src/app/blog/[postKey]/layout.tsx
+++ b/apps/blog/src/app/blog/[postKey]/layout.tsx
@@ -3,7 +3,7 @@ import HomeButtonWrapper from "@components/HomeButtonWrapper";
 import { ScrollToTopButton } from "@repo/components";
 import { SEO } from "@/constants/seo";
 
-export const revalidate = 3600;
+export const dynamic = "force-dynamic";
 
 type BlogPostParams = Promise<{ postKey?: string }>;
 

--- a/apps/blog/src/app/blog/[postKey]/page.tsx
+++ b/apps/blog/src/app/blog/[postKey]/page.tsx
@@ -1,5 +1,4 @@
 import { notFound } from "next/navigation";
-import getHomeData from "@data/getHomeData";
 import getPostData from "@data/getPostData";
 import { Highlight, Title } from "@repo/components";
 
@@ -7,15 +6,7 @@ import { getFileContents } from "@utils/fileUtils";
 import MdxWrapper from "@components/MdxWrapper";
 import { BlogPostingJsonLd } from "@components/JsonLd";
 
-export const revalidate = 3600;
-
-export async function generateStaticParams() {
-  const { data } = await getHomeData();
-
-  return data.posts
-    .filter((post) => post.postKey && !post.externalUrl)
-    .map((post) => ({ postKey: post.postKey! }));
-}
+export const dynamic = "force-dynamic";
 
 type BlogPostParams = Promise<{ postKey?: string }>;
 

--- a/apps/blog/src/app/blog/page.tsx
+++ b/apps/blog/src/app/blog/page.tsx
@@ -5,7 +5,7 @@ import TagProvider from "./_components/TagProvider";
 import getBlogData from "@data/getBlogData";
 import HomeButtonWrapper from "@components/HomeButtonWrapper";
 
-export const revalidate = 3600;
+export const dynamic = "force-dynamic";
 
 export default async function BlogListPage() {
   const { data, error } = await getBlogData();

--- a/apps/blog/src/app/page.tsx
+++ b/apps/blog/src/app/page.tsx
@@ -4,7 +4,7 @@ import Extra from "./_components/Extra";
 import Introduce from "./_components/Introduce";
 import Projects from "./_components/Projects";
 
-export const revalidate = 3600;
+export const dynamic = "force-dynamic";
 
 export default async function Home() {
   const { data, error } = await getHomeData();

--- a/apps/blog/src/app/sitemap.ts
+++ b/apps/blog/src/app/sitemap.ts
@@ -2,7 +2,7 @@ import getHomeData from "@data/getHomeData";
 import { MetadataRoute } from "next";
 import { SEO } from "@/constants/seo";
 
-export const revalidate = 3600;
+export const dynamic = "force-dynamic";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const { data, error } = await getHomeData();


### PR DESCRIPTION
## Summary
- Docker 빌드 환경(GitHub Actions)에서 Cloud SQL에 네트워크 접근이 불가하여 ISR 프리렌더링 시 빈 데이터로 캐싱되던 문제 해결
- `revalidate = 3600`(ISR) → `dynamic = "force-dynamic"`으로 전환하여 런타임에서만 DB 데이터를 가져오도록 변경
- 불필요해진 빌드 시 시크릿 주입 로직 제거 (Dockerfile, CI)
- 빌드 시 DB 접근이 필요한 `generateStaticParams` 제거

## Changes
- `apps/blog/src/app/page.tsx` — force-dynamic 전환
- `apps/blog/src/app/blog/page.tsx` — force-dynamic 전환
- `apps/blog/src/app/blog/[postKey]/page.tsx` — force-dynamic 전환 + generateStaticParams 제거
- `apps/blog/src/app/blog/[postKey]/layout.tsx` — force-dynamic 전환
- `apps/blog/src/app/sitemap.ts` — force-dynamic 전환
- `apps/blog/Dockerfile` — 시크릿 마운트 제거
- `.github/actions/auto_deploy/action.yml` — 시크릿 관련 스텝 제거