### PR TITLE
Hotfix: cacheTag 제거 - 게시글 로딩 버그 수정

### DIFF
--- a/apps/blog/src/shared/lib/db.ts
+++ b/apps/blog/src/shared/lib/db.ts
@@ -1,5 +1,5 @@
 import pg from "pg";
-import { unstable_cache, cacheTag } from "next/cache";
+import { unstable_cache } from "next/cache";
 
 const { Pool } = pg;
 
@@ -62,7 +62,6 @@ export const getPosts = unstable_cache(
 
 export const getPost = unstable_cache(
   async (postKey: string): Promise<PostRow | null> => {
-    cacheTag(`post-${postKey}`);
     const { rows } = await pool.query(
       'SELECT * FROM posts WHERE "postKey" = $1',
       [postKey],


### PR DESCRIPTION
## Summary

`unstable_cache` 내부에서 `cacheTag`를 호출할 경우, `next.config.ts`에 `experimental: { dynamicIO: true }` 설정이 없으면 에러가 발생합니다. 이로 인해 `getPost` 함수가 실패하면서 블로그 게시글이 로딩되지 않는 버그가 발생하였습니다.

## Changes

- `apps/blog/src/shared/lib/db.ts`: `cacheTag` import 및 `getPost` 내부 `cacheTag` 호출 제거

## Root Cause

- `cacheTag`는 `'use cache'` 디렉티브 또는 `dynamicIO` 활성화 환경에서만 정상 동작
- `next.config.ts`에 해당 설정이 없어 런타임 에러 발생 → `getPost` 호출 실패 → 게시글 미표시

## Testing
- [ ] 블로그 게시글 목록이 정상적으로 로딩되는지 확인
- [ ] 개별 게시글 페이지가 정상적으로 렌더링되는지 확인