### PR TITLE
fix(db): cacheTag 제거 - dynamicIO 미설정으로 인한 getPost 에러 수정

### DIFF
--- a/apps/blog/src/shared/lib/db.ts
+++ b/apps/blog/src/shared/lib/db.ts
@@ -1,5 +1,5 @@
 import pg from "pg";
-import { unstable_cache, cacheTag } from "next/cache";
+import { unstable_cache } from "next/cache";
 
 const { Pool } = pg;
 
@@ -62,7 +62,6 @@ export const getPosts = unstable_cache(
 
 export const getPost = unstable_cache(
   async (postKey: string): Promise<PostRow | null> => {
-    cacheTag(`post-${postKey}`);
     const { rows } = await pool.query(
       'SELECT * FROM posts WHERE "postKey" = $1',
       [postKey],


### PR DESCRIPTION
## Summary

`getPost` 함수에서 사용하던 `cacheTag`를 제거합니다.

`cacheTag`는 Next.js의 `dynamicIO` 옵션이 활성화된 환경에서만 동작하는 API입니다.
현재 프로젝트에서는 `dynamicIO`가 설정되어 있지 않아, `cacheTag` 호출 시 런타임 에러가 발생하고 있었습니다.
이전 커밋(8fe7f15)에서 개별 게시물 재검증을 위해 도입했으나, 전제 조건이 충족되지 않아 롤백합니다.

## Changes

- `apps/blog/src/shared/lib/db.ts`: `getPost` 함수 내 `cacheTag(\`post-${postKey}\`)` 호출 제거
- 미사용 `cacheTag` import 제거

## Testing

- [ ] 게시물 상세 페이지(`/blog/[postKey]`)가 에러 없이 정상 렌더링되는지 확인
- [ ] 게시물 목록 페이지가 정상 동작하는지 확인
