### PR TITLE
fix(deploy): 빌드 시점 DB 시크릿 주입으로 ISR 빈 페이지 문제 해결

### DIFF
--- a/.github/actions/auto_deploy/action.yml
+++ b/.github/actions/auto_deploy/action.yml
@@ -38,6 +38,7 @@ runs:
       id: fetch_db_secrets
       if: ${{ inputs.package == 'blog' }}
       run: |
+        set -euo pipefail
         echo "DB_USER=$(gcloud secrets versions access latest --secret=db-user)" >> $GITHUB_ENV
         echo "DB_HOST=$(gcloud secrets versions access latest --secret=db-host)" >> $GITHUB_ENV
         echo "DB_NAME=$(gcloud secrets versions access latest --secret=db-name)" >> $GITHUB_ENV

--- a/.github/actions/auto_deploy/action.yml
+++ b/.github/actions/auto_deploy/action.yml
@@ -34,13 +34,34 @@ runs:
         gcloud auth configure-docker ${{inputs.gcp_region}}-docker.pkg.dev
       shell: bash
 
+    - name: Fetch DB Secrets for Blog Build
+      id: fetch_db_secrets
+      if: ${{ inputs.package == 'blog' }}
+      run: |
+        echo "DB_USER=$(gcloud secrets versions access latest --secret=db-user)" >> $GITHUB_ENV
+        echo "DB_HOST=$(gcloud secrets versions access latest --secret=db-host)" >> $GITHUB_ENV
+        echo "DB_NAME=$(gcloud secrets versions access latest --secret=db-name)" >> $GITHUB_ENV
+        echo "DB_PASSWORD=$(gcloud secrets versions access latest --secret=db-password)" >> $GITHUB_ENV
+        echo "DB_PORT=$(gcloud secrets versions access latest --secret=db-port)" >> $GITHUB_ENV
+      shell: bash
+
     - name: Docker Build and Push Image
       id: docker_build_and_push_image
       run: |
         IMAGE_NAME="${{inputs.gcp_region}}-docker.pkg.dev/${{inputs.gcp_project_id}}/monorepo-${{inputs.package}}/deploy"
 
-        docker build \
-          -t $IMAGE_NAME:latest -f apps/${{inputs.package}}/Dockerfile .
+        if [ "${{inputs.package}}" = "blog" ]; then
+          docker build \
+            --build-arg DB_USER="$DB_USER" \
+            --build-arg DB_HOST="$DB_HOST" \
+            --build-arg DB_NAME="$DB_NAME" \
+            --build-arg DB_PASSWORD="$DB_PASSWORD" \
+            --build-arg DB_PORT="$DB_PORT" \
+            -t $IMAGE_NAME:latest -f apps/${{inputs.package}}/Dockerfile .
+        else
+          docker build \
+            -t $IMAGE_NAME:latest -f apps/${{inputs.package}}/Dockerfile .
+        fi
 
         docker push $IMAGE_NAME:latest
       shell: bash

--- a/apps/blog/Dockerfile
+++ b/apps/blog/Dockerfile
@@ -19,6 +19,18 @@ FROM node:22.14.0-alpine3.21 AS build
 
 WORKDIR /app
 
+ARG DB_USER
+ARG DB_HOST
+ARG DB_NAME
+ARG DB_PASSWORD
+ARG DB_PORT
+
+ENV DB_USER=$DB_USER
+ENV DB_HOST=$DB_HOST
+ENV DB_NAME=$DB_NAME
+ENV DB_PASSWORD=$DB_PASSWORD
+ENV DB_PORT=$DB_PORT
+
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/package.json ./package.json
 COPY --from=deps /app/pnpm-lock.yaml ./pnpm-lock.yaml


### PR DESCRIPTION
## Summary

배포 직후 블로그 게시물 목록이 비어있는 문제를 해결합니다.

Next.js ISR은 빌드 시점에 페이지를 정적 생성하는데, GitHub Actions의 Docker 빌드 환경에는
DB 환경변수가 없어 `getPosts` 호출이 실패하고 빈 페이지가 생성되었습니다.
이후 `revalidate = 3600` 설정에 의해 최대 1시간 동안 빈 페이지가 서빙되는 문제가 있었습니다.

GCP Secret Manager에서 DB 시크릿을 빌드 전에 가져와 `--build-arg`로 주입하여,
빌드 시점에 실제 DB 데이터로 정적 페이지를 생성하도록 수정합니다.

## Changes

- `apps/blog/Dockerfile`: `build` 스테이지에 DB 환경변수 ARG/ENV 추가 (`runner` 스테이지엔 미포함으로 최종 이미지에 자격증명 미포함)
- `.github/actions/auto_deploy/action.yml`: blog 패키지 빌드 전 GCP Secret Manager에서 DB 시크릿 fetch 후 `docker build --build-arg`로 주입