### PR TITLE
fix: 배포 후 ISR revalidation 자동 트리거로 초기 데이터 누락 수정

### DIFF
--- a/.github/actions/auto_deploy/action.yml
+++ b/.github/actions/auto_deploy/action.yml
@@ -53,7 +53,18 @@ runs:
           --region=${{inputs.gcp_region}} \
           --platform=managed \
           --allow-unauthenticated \
-          --set-secrets=DB_USER=db-user:latest,DB_HOST=db-host:latest,DB_NAME=db-name:latest,DB_PASSWORD=db-password:latest,DB_PORT=db-port:latest
+          --set-secrets=DB_USER=db-user:latest,DB_HOST=db-host:latest,DB_NAME=db-name:latest,DB_PASSWORD=db-password:latest,DB_PORT=db-port:latest,VALIDATED_API_KEY=validated-api-key:latest
+      shell: bash
+
+    - name: Trigger ISR Revalidation
+      if: ${{ inputs.package == 'blog' }}
+      run: |
+        SERVICE_URL=$(gcloud run services describe ${{inputs.package}} \
+          --region=${{inputs.gcp_region}} \
+          --format='value(status.url)')
+
+        curl -X POST "$SERVICE_URL/api/revalidate" \
+          -H "x-api-key: $(gcloud secrets versions access latest --secret=validated-api-key)"
       shell: bash
 
     - name: Deploy to Cloud Run

--- a/apps/blog/src/app/api/revalidate/route.ts
+++ b/apps/blog/src/app/api/revalidate/route.ts
@@ -1,0 +1,14 @@
+import { revalidateTag } from "next/cache";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(request: NextRequest) {
+  const apiKey = request.headers.get("x-api-key");
+
+  if (apiKey !== process.env.VALIDATED_API_KEY) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  revalidateTag("posts");
+
+  return NextResponse.json({ revalidated: true });
+}

--- a/apps/blog/src/app/api/revalidate/route.ts
+++ b/apps/blog/src/app/api/revalidate/route.ts
@@ -1,4 +1,4 @@
-import { revalidateTag } from "next/cache";
+import { revalidatePath } from "next/cache";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function POST(request: NextRequest) {
@@ -8,7 +8,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  revalidateTag("posts");
+  revalidatePath("/", "layout");
 
   return NextResponse.json({ revalidated: true });
 }


### PR DESCRIPTION
## Summary

배포 직후 ISR 캐시가 빈 데이터로 고정되어 게시글이 노출되지 않던 문제를 수정합니다.
배포 완료 후 `/api/revalidate`를 자동 호출하여 캐시를 즉시 무효화하고,
첫 요청부터 DB의 최신 데이터가 정상 노출되도록 개선하였습니다.

## Changes

- `apps/blog/src/app/api/revalidate/route.ts` 추가
  - `VALIDATED_API_KEY` 헤더 인증 후 `revalidateTag("posts")` 호출
- `.github/actions/auto_deploy/action.yml` 수정
  - Cloud Run 배포 시 `VALIDATED_API_KEY` 시크릿 주입 추가
  - 배포 완료 직후 `/api/revalidate` 자동 호출 스텝 추가