### PR TITLE
fix(blog): SSG 빌드 시 게시글이 로드되지 않는 문제 수정

### DIFF
--- a/.github/actions/auto_deploy/action.yml
+++ b/.github/actions/auto_deploy/action.yml
@@ -39,8 +39,24 @@ runs:
       run: |
         IMAGE_NAME="${{inputs.gcp_region}}-docker.pkg.dev/${{inputs.gcp_project_id}}/monorepo-${{inputs.package}}/deploy"
 
-        docker build \
-          -t $IMAGE_NAME:latest -f apps/${{inputs.package}}/Dockerfile .
+        if [ "${{inputs.package}}" = "blog" ]; then
+          DB_USER=$(gcloud secrets versions access latest --secret=db-user)
+          DB_HOST=$(gcloud secrets versions access latest --secret=db-host)
+          DB_NAME=$(gcloud secrets versions access latest --secret=db-name)
+          DB_PASSWORD=$(gcloud secrets versions access latest --secret=db-password)
+          DB_PORT=$(gcloud secrets versions access latest --secret=db-port)
+
+          docker build \
+            --build-arg DB_USER="$DB_USER" \
+            --build-arg DB_HOST="$DB_HOST" \
+            --build-arg DB_NAME="$DB_NAME" \
+            --build-arg DB_PASSWORD="$DB_PASSWORD" \
+            --build-arg DB_PORT="$DB_PORT" \
+            -t $IMAGE_NAME:latest -f apps/${{inputs.package}}/Dockerfile .
+        else
+          docker build \
+            -t $IMAGE_NAME:latest -f apps/${{inputs.package}}/Dockerfile .
+        fi
 
         docker push $IMAGE_NAME:latest
       shell: bash
@@ -54,17 +70,6 @@ runs:
           --platform=managed \
           --allow-unauthenticated \
           --set-secrets=DB_USER=db-user:latest,DB_HOST=db-host:latest,DB_NAME=db-name:latest,DB_PASSWORD=db-password:latest,DB_PORT=db-port:latest,VALIDATED_API_KEY=validated-api-key:latest
-      shell: bash
-
-    - name: Trigger ISR Revalidation
-      if: ${{ inputs.package == 'blog' }}
-      run: |
-        SERVICE_URL=$(gcloud run services describe ${{inputs.package}} \
-          --region=${{inputs.gcp_region}} \
-          --format='value(status.url)')
-
-        curl -X POST "$SERVICE_URL/api/revalidate" \
-          -H "x-api-key: $(gcloud secrets versions access latest --secret=validated-api-key)"
       shell: bash
 
     - name: Deploy to Cloud Run

--- a/apps/blog/Dockerfile
+++ b/apps/blog/Dockerfile
@@ -33,6 +33,18 @@ RUN npm install -g pnpm turbo
 
 RUN pnpm install --frozen-lockfile
 
+ARG DB_USER
+ARG DB_HOST
+ARG DB_NAME
+ARG DB_PASSWORD
+ARG DB_PORT
+
+ENV DB_USER=$DB_USER
+ENV DB_HOST=$DB_HOST
+ENV DB_NAME=$DB_NAME
+ENV DB_PASSWORD=$DB_PASSWORD
+ENV DB_PORT=$DB_PORT
+
 RUN turbo run build --filter=blog --no-daemon
 
 FROM node:22.14.0-alpine3.21 AS runner

--- a/apps/blog/src/shared/api/getBlogData.ts
+++ b/apps/blog/src/shared/api/getBlogData.ts
@@ -1,4 +1,3 @@
-import { PHASE_PRODUCTION_BUILD } from "next/constants";
 import { getPosts, getAllTags } from "@shared/lib";
 import { isPostVisible } from "@entities/post";
 import type { PostData } from "@shared/types";
@@ -9,10 +8,6 @@ export interface BlogData {
 }
 
 const getBlogData = async () => {
-  if (process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD) {
-    return { data: { posts: [] as PostData[], tags: [] as string[] }, error: null };
-  }
-
   try {
     const [allPosts, tags] = await Promise.all([
       getPosts("", "DESC"),

--- a/apps/blog/src/shared/api/getHomeData.ts
+++ b/apps/blog/src/shared/api/getHomeData.ts
@@ -1,13 +1,8 @@
-import { PHASE_PRODUCTION_BUILD } from "next/constants";
 import { getPosts } from "@shared/lib";
 import { isPostVisible } from "@entities/post";
 import type { PostData } from "@shared/types";
 
 const getHomeData = async () => {
-  if (process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD) {
-    return { data: { posts: [] as PostData[] }, error: null };
-  }
-
   try {
     const allPosts = await getPosts("", "DESC");
 


### PR DESCRIPTION
## Summary

배포된 블로그에서 게시글이 전혀 표시되지 않는 문제를 수정합니다.

빌드 시 `PHASE_PRODUCTION_BUILD` 조건으로 빈 데이터를 반환하고 있었고,
`revalidate = false` 설정으로 인해 빈 페이지가 영원히 캐시되는 구조였습니다.
Cloud Run(서버리스) 환경 특성상 ISR 캐시가 인스턴스 간에 공유되지 않아
배포 후 revalidation을 트리거해도 신뢰성 있게 동작하지 않았습니다.

순수 SSG 방식으로 전환하여, 빌드 시 GCP Secret Manager에서 DB 정보를 읽어
정적 페이지 생성 시점에 실제 게시글 데이터를 포함하도록 수정합니다.

## Changes

- `getBlogData.ts`, `getHomeData.ts`: 빌드 시 DB 조회를 막던 `PHASE_PRODUCTION_BUILD` 조건 제거
- `Dockerfile`: `ARG` / `ENV` 추가로 빌드 시 DB 환경변수 주입 가능하도록 수정
- `auto_deploy/action.yml`: Docker 빌드 전 GCP Secret Manager에서 DB 값을 읽어 `--build-arg`로 전달
- `auto_deploy/action.yml`: 불필요해진 `Trigger ISR Revalidation` 스텝 제거

## Testing

- [ ] 배포 후 블로그 게시글 목록이 정상 표시되는지 확인
- [ ] GitHub Actions Docker 빌드 로그에서 DB 연결 성공 여부 확인
