### PR TITLE
style(blog): MDX 포스트 본문 스타일 전면 개선 및 다크모드 코드 하이라이트 추가

### DIFF
--- a/apps/blog/src/app/blog/[postKey]/page.tsx
+++ b/apps/blog/src/app/blog/[postKey]/page.tsx
@@ -44,15 +44,13 @@ export default async function BlogPostPage({
   }
 
   return (
-    <article>
+    <article className="max-w-[760px] mx-auto">
       <BlogPostingJsonLd title={title} postKey={postKey ?? ""} tags={tags} />
-      <header>
+      <header className="pb-[32px] border-b border-[var(--border)]">
         <Title title={title} />
-        <div className="mt-[10px] mb-[20px]">
+        <div className="mt-[14px] flex flex-wrap gap-[6px]">
           {tags.map((tag) => (
-            <Highlight key={tag} className="mr-[4px]">
-              {tag}
-            </Highlight>
+            <Highlight key={tag}>{tag}</Highlight>
           ))}
         </div>
       </header>

--- a/apps/blog/src/app/globals.css
+++ b/apps/blog/src/app/globals.css
@@ -1,4 +1,5 @@
 @import "./reset.css";
+@import "./hljs-dark.css";
 @import "tailwindcss";
 @import "@repo/components/theme.css";
 
@@ -132,6 +133,33 @@
 
 @utility max-w-content {
   max-width: 1060px;
+}
+
+/* ===== MDX Code Block Theme ===== */
+/* atom-one-light sets .hljs { background: #fafafa } — override to match pre background */
+.mdx-body .hljs {
+  background: #f4f1ed;
+}
+
+.dark .mdx-body .hljs {
+  background: #282c34;
+}
+
+/* ===== MDX Prose Content ===== */
+/* reset.css의 list-style: none을 특이성으로 덮어씀 (.mdx-body ul > ul 순서) */
+.mdx-body ul {
+  list-style: disc;
+  padding-left: 1.75em;
+}
+
+.mdx-body ol {
+  list-style: decimal;
+  padding-left: 1.75em;
+}
+
+.mdx-body li {
+  margin-top: 0.3em;
+  margin-bottom: 0.3em;
 }
 
 /* ===== @repo/components Style Overrides ===== */

--- a/apps/blog/src/app/hljs-dark.css
+++ b/apps/blog/src/app/hljs-dark.css
@@ -1,0 +1,77 @@
+/* Dark mode highlight.js overrides — atom-one-dark palette */
+/* .dark .hljs has higher specificity than .hljs, so it wins over the imported light theme */
+
+.dark .hljs {
+  background: #282c34;
+  color: #abb2bf;
+}
+
+.dark .hljs-comment,
+.dark .hljs-quote {
+  color: #5c6370;
+  font-style: italic;
+}
+
+.dark .hljs-doctag,
+.dark .hljs-keyword,
+.dark .hljs-formula {
+  color: #c678dd;
+}
+
+.dark .hljs-section,
+.dark .hljs-name,
+.dark .hljs-selector-tag,
+.dark .hljs-deletion,
+.dark .hljs-subst {
+  color: #e06c75;
+}
+
+.dark .hljs-literal {
+  color: #56b6c2;
+}
+
+.dark .hljs-string,
+.dark .hljs-regexp,
+.dark .hljs-addition,
+.dark .hljs-attribute,
+.dark .hljs-meta .hljs-string {
+  color: #98c379;
+}
+
+.dark .hljs-attr,
+.dark .hljs-variable,
+.dark .hljs-template-variable,
+.dark .hljs-type,
+.dark .hljs-selector-class,
+.dark .hljs-selector-attr,
+.dark .hljs-selector-pseudo,
+.dark .hljs-number {
+  color: #d19a66;
+}
+
+.dark .hljs-symbol,
+.dark .hljs-bullet,
+.dark .hljs-link,
+.dark .hljs-meta,
+.dark .hljs-selector-id,
+.dark .hljs-title {
+  color: #61aeee;
+}
+
+.dark .hljs-built_in,
+.dark .hljs-title.class_,
+.dark .hljs-class .hljs-title {
+  color: #e6c07b;
+}
+
+.dark .hljs-emphasis {
+  font-style: italic;
+}
+
+.dark .hljs-strong {
+  font-weight: bold;
+}
+
+.dark .hljs-link {
+  text-decoration: underline;
+}

--- a/apps/blog/src/shared/ui/MdxComponents/MdxComponents.tsx
+++ b/apps/blog/src/shared/ui/MdxComponents/MdxComponents.tsx
@@ -1,16 +1,22 @@
 import type { MDXComponents } from "mdx/types";
-import "highlight.js/styles/1c-light.css";
+import "highlight.js/styles/atom-one-light.css";
 
 const P = ({ children }: { children?: React.ReactNode }) => (
-  <p className="font-normal">{children}</p>
+  <p className="text-[17px] leading-[1.9] mb-[1.4em] font-normal">{children}</p>
 );
 
 const H2 = ({ children }: { children?: React.ReactNode }) => (
-  <h2 className="text-[32px] font-bold my-[16px]">{children}</h2>
+  <h2 className="text-[26px] font-bold mt-[2.5em] mb-[0.75em] pb-[0.5em] border-b border-[var(--border)] leading-[1.4]">
+    {children}
+  </h2>
 );
 
 const H3 = ({ children }: { children?: React.ReactNode }) => (
-  <h3 className="text-[24px] font-bold my-[16px]">{children}</h3>
+  <h3 className="text-[21px] font-bold mt-[2em] mb-[0.5em] leading-[1.4]">{children}</h3>
+);
+
+const H4 = ({ children }: { children?: React.ReactNode }) => (
+  <h4 className="text-[18px] font-bold mt-[1.5em] mb-[0.4em] leading-[1.4]">{children}</h4>
 );
 
 const A = ({
@@ -21,30 +27,49 @@ const A = ({
   children?: React.ReactNode;
 }) => (
   <a
-    className="text-[20px] font-semibold text-blue-600 underline"
+    className="text-blue-500 underline underline-offset-2 hover:opacity-75 transition-opacity"
     href={href}
     target="_blank"
+    rel="noopener noreferrer"
   >
     {children}
   </a>
 );
 
+const Blockquote = ({ children }: { children?: React.ReactNode }) => (
+  <blockquote className="my-[1.75em] pl-[1.25em] border-l-[4px] border-[var(--accent)] bg-[var(--accent-soft)] dark:bg-[var(--surface-raised)] py-[0.75em] pr-[1.25em] rounded-r-[6px] text-[var(--ink-secondary)]">
+    {children}
+  </blockquote>
+);
+
 const Pre = ({ children }: { children?: React.ReactNode }) => (
-  <pre className="m-[10px] p-[10px] bg-[#87837826] relative overflow-auto rounded-[8px]">
+  <pre className="my-[1.75em] p-[1.25em] rounded-[8px] overflow-auto relative bg-[#f4f1ed] dark:bg-[#282c34]">
     {children}
   </pre>
 );
 
 const Ul = ({ children }: { children?: React.ReactNode }) => (
-  <ul className="m-[10px]">{children}</ul>
+  <ul className="my-[1em]">{children}</ul>
 );
 
 const Ol = ({ children }: { children?: React.ReactNode }) => (
-  <ol className="m-[10px]">{children}</ol>
+  <ol className="my-[1em]">{children}</ol>
 );
 
 const Li = ({ children }: { children?: React.ReactNode }) => (
-  <li> - {children}</li>
+  <li className="text-[17px] leading-[1.9]">{children}</li>
+);
+
+const Hr = () => (
+  <hr className="my-[2.5em] border-none h-[1px] bg-[var(--border)]" />
+);
+
+const Img = ({ src, alt }: { src?: string; alt?: string }) => (
+  <img
+    src={src}
+    alt={alt ?? ""}
+    className="max-w-full rounded-[8px] my-[1.75em] mx-auto block"
+  />
 );
 
 const Code = ({
@@ -61,10 +86,10 @@ const Code = ({
 
     return (
       <>
-        <p className="font-normal text-[12px] absolute top-[2px] right-[5px] bg-transparent">
+        <p className="font-normal text-[11px] absolute top-[8px] right-[12px] bg-transparent text-[#888]">
           {preLanguage}
         </p>
-        <code className="text-[16px] p-[4px] font-normal font-[Paperlogy]">
+        <code className="text-[15px] font-normal font-[Paperlogy] leading-[1.7]">
           {children}
         </code>
       </>
@@ -72,7 +97,7 @@ const Code = ({
   }
 
   return (
-    <code className="text-[16px] p-[2px] text-[#eb5757] bg-[#87837826] rounded-[4px] font-semibold font-[Paperlogy]">
+    <code className="text-[14px] px-[5px] py-[2px] text-[#eb5757] dark:text-[var(--accent)] bg-[#f1efef] dark:bg-[#2a2a35] rounded-[4px] font-semibold font-[Paperlogy]">
       {children}
     </code>
   );
@@ -82,11 +107,15 @@ const MdxComponents: MDXComponents = {
   p: P,
   h2: H2,
   h3: H3,
+  h4: H4,
   a: A,
+  blockquote: Blockquote,
   pre: Pre,
   ul: Ul,
   ol: Ol,
   li: Li,
+  hr: Hr,
+  img: Img,
   code: Code,
 };
 

--- a/apps/blog/src/shared/ui/MdxWrapper/MdxWrapper.tsx
+++ b/apps/blog/src/shared/ui/MdxWrapper/MdxWrapper.tsx
@@ -10,7 +10,7 @@ const MdxWrapper = ({ source }: MdxWrapperProps) => {
   return (
     <>
       {source ? (
-        <article className="w-full py-[40px] px-0 text-[20px] font-normal leading-normal">
+        <div className="mdx-body w-full pt-[40px]">
           <MDXRemote
             source={source}
             components={MdxComponents}
@@ -21,7 +21,7 @@ const MdxWrapper = ({ source }: MdxWrapperProps) => {
               },
             }}
           />
-        </article>
+        </div>
       ) : (
         <p className="text-center text-gray-500 text-lg py-10">
           게시물 콘텐츠를 로드할 수 없습니다.

--- a/packages/components/src/HomeButton.tsx
+++ b/packages/components/src/HomeButton.tsx
@@ -1,5 +1,6 @@
 const HomeButton = ({ onClick }: { onClick: () => void }) => {
-  const className = "flex items-center justify-center m-auto mb-[20px] w-[40px] h-[40px] md:w-[50px] md:h-[50px] lg:w-[60px] lg:h-[60px] text-[28px] md:text-[34px] lg:text-[40px] rounded-[10px] shadow-inner-border";
+  const className =
+    "flex items-center justify-center m-auto mb-[20px] w-[40px] h-[40px] md:w-[50px] md:h-[50px] lg:w-[60px] lg:h-[60px] text-[28px] md:text-[34px] lg:text-[40px] rounded-[10px] shadow-inner-border";
 
   return (
     <button className={className} onClick={onClick} aria-label="홈으로 이동">


### PR DESCRIPTION
## Summary

블로그 포스트 본문의 가독성을 높이기 위해 MDX 컴포넌트 타이포그래피를 전면 개선하고,
포스트 페이지 레이아웃을 정비했습니다. 또한 다크모드에서 코드 블록이 올바른 테마로
표시되도록 atom-one-dark 기반의 highlight.js 오버라이드를 추가했습니다.

## Changes

### MDX 컴포넌트 스타일 개선
- `h2` / `h3` 타이포그래피 및 여백 조정, `h4` 컴포넌트 신규 추가
- `blockquote`, `hr`, `img` 컴포넌트 신규 추가
- `p`, `li` 폰트 크기(17px) / 줄 간격(1.9) 통일
- 인라인 `code` 다크모드 스타일 추가
- 코드 블록 하이라이트 테마를 `1c-light` → `atom-one-light`로 변경
- 링크에 `rel="noopener noreferrer"` 추가
- `MdxWrapper` 래퍼를 `article` → `div.mdx-body`로 변경하여 CSS 스코프 분리

### 블로그 포스트 페이지 레이아웃
- 포스트 본문 최대 너비 760px 제한 및 중앙 정렬
- 헤더 하단 border 추가, 태그 flex wrap 레이아웃으로 개선

### 다크모드 코드 하이라이트 테마
- `hljs-dark.css` 신규 추가 — atom-one-dark 팔레트 기반 `.dark .hljs-*` 오버라이드
- `globals.css`에 `hljs` 배경색 라이트/다크 override 및 MDX prose(ul/ol/li) 스타일 추가

## Testing
- [ ] 라이트모드에서 포스트 본문 타이포그래피 정상 렌더링 확인
- [ ] 다크모드에서 코드 블록 하이라이트 테마 정상 표시 확인
- [ ] h2 / h3 / h4 / blockquote / hr / img 요소가 있는 포스트에서 레이아웃 확인
- [ ] 인라인 코드 스타일 라이트/다크 모드 확인