### PR TITLE
Storybook 배포 CI 구축 및 안정화

### DIFF
--- a/.github/workflows/storybook_ci.yml
+++ b/.github/workflows/storybook_ci.yml
@@ -1,11 +1,9 @@
-name: storybook_pages
+name: storybook_ci
 
 on:
-  push:
-    branches:
-      - main
+  pull_request:
     paths:
-      - ".github/workflows/storybook_pages.yml"
+      - ".github/workflows/storybook_ci.yml"
       - "apps/storybook/**"
       - "packages/components/**"
       - "packages/content/**"
@@ -20,20 +18,15 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
-  group: pages
-  cancel-in-progress: false
+  group: storybook-ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  deploy:
-    name: build-and-deploy
+  integration:
+    name: integration
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
       - name: Checkout
@@ -56,15 +49,3 @@ jobs:
 
       - name: Build Storybook
         run: pnpm build:storybook
-
-      - name: Configure GitHub Pages
-        uses: actions/configure-pages@v5
-
-      - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v4
-        with:
-          path: apps/storybook/storybook-static
-
-      - name: Deploy GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@
    <img src='https://img.shields.io/badge/portfolio-readme-633DE5?style=for-the-badge&labelColor=4C566A'>
 </a>
 
+<br>
+
+<a href='https://k1my3ch4n.github.io/dev-next-blog/' target="_blank">
+   <img src='https://img.shields.io/badge/storybook-site-FF4785?style=for-the-badge&labelColor=4C566A'>
+</a>
+
 <hr>
 
 <h3>📝 관련 포스트</h3>
@@ -73,6 +79,7 @@
 - Vite 와 yarn workspace 를 사용했던 프로젝트를 Next 와 Turborepo 를 사용해 마이그레이션 진행했습니다.
 - css 도구로 tailwindcss 를 사용했습니다.
 - Docker 와 Google Cloud Platform 을 사용해 페이지 배포 진행했습니다.
+- 공용 UI 컴포넌트는 Storybook 으로 문서화하고 GitHub Pages 에 정적 배포합니다.
 
 1. **노드 버전 (>= 20.0.0)**
 
@@ -94,9 +101,44 @@
 - [Next](https://nextjs.org/)
 - [TurboRepo](https://turborepo.com/)
 - [Tailwindcss](https://tailwindcss.com/)
+- [Storybook](https://storybook.js.org/)
 - [Github action](https://github.com/features/actions)
+- [GitHub Pages](https://pages.github.com/)
 - [Google Cloud Platform](https://cloud.google.com/?hl=ko)
 - [Docker](https://www.docker.com/)
+
+<img src="https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/rainbow.png" width="100%" alt="rainbow" />
+
+## 📚 Storybook
+
+[`packages/components`](./packages/components)의 공용 UI 컴포넌트를 독립적으로 개발하고 검증할 수 있도록 [`apps/storybook`](./apps/storybook)에 Storybook workspace를 구성했습니다.
+
+### 제공 범위
+
+- Foundations, Icons, Primitives, Layout, Feedback, Interactive, Composite 단위의 stories
+- Light / Dark 전역 테마 전환
+- Autodocs 기반 컴포넌트 API 문서
+- 모바일, 태블릿, 데스크톱 viewport
+- `play` 함수를 이용한 사용자 interaction 검증
+- Storybook Vitest addon과 Playwright 기반 브라우저 테스트
+- 접근성 오류 검사
+
+### 실행 및 검증
+
+| 명령 | 설명 |
+|------|------|
+| `pnpm storybook` | 로컬 Storybook 실행 (`http://localhost:6006`) |
+| `pnpm --filter=storybook check-types` | Storybook 타입 검사 |
+| `pnpm test:storybook` | 전체 story 및 interaction 테스트 |
+| `pnpm --filter=storybook build-storybook` | `storybook-static/` 정적 파일 생성 |
+
+### 배포
+
+- 배포 주소: [https://k1my3ch4n.github.io/dev-next-blog/](https://k1my3ch4n.github.io/dev-next-blog/)
+- 호스팅: GitHub Pages
+- Workflow: [`.github/workflows/storybook_pages.yml`](./.github/workflows/storybook_pages.yml)
+- `main` 브랜치에서 Storybook 또는 관련 공용 패키지가 변경되면 정적 빌드 후 자동 배포됩니다.
+- Blog과 Portfolio의 Cloud Run 배포와 분리하여 Storybook 배포 실패가 기존 애플리케이션 배포에 영향을 주지 않도록 구성했습니다.
 
 <img src="https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/rainbow.png" width="100%" alt="rainbow" />
 
@@ -428,12 +470,16 @@ monorepo
 │   │       ├── widgets                 # 페이지 섹션 (home-blog, home-works 등)
 │   │       ├── posts                   # MD 게시글 파일
 │   │       └── proxy.ts                # Next.js Proxy (라우팅 제어)
-│   └── portfolio
+│   ├── portfolio
+│   │   └── src
+│   │       ├── app                     # Next.js App Router
+│   │       ├── features                # 기능 모듈 (WorkFilter, ProjectModal)
+│   │       ├── shared                  # 공통 모듈 (assets, data, hooks, lib, types, ui)
+│   │       └── widgets                 # 페이지 섹션 (Hero, WorkSection, AboutSection 등)
+│   └── storybook
+│       ├── .storybook                  # Storybook framework 및 preview 설정
 │       └── src
-│           ├── app                     # Next.js App Router
-│           ├── features                # 기능 모듈 (WorkFilter, ProjectModal)
-│           ├── shared                  # 공통 모듈 (assets, data, hooks, lib, types, ui)
-│           └── widgets                 # 페이지 섹션 (Hero, WorkSection, AboutSection 등)
+│           └── stories                 # 공용 컴포넌트 stories
 └── packages
     ├── components                      # 공통 UI 컴포넌트 (@repo/components)
     ├── content                         # 공통 콘텐츠 데이터 (@repo/content — WorkItem, 해커톤)

--- a/apps/storybook/.storybook/manager.ts
+++ b/apps/storybook/.storybook/manager.ts
@@ -1,0 +1,9 @@
+import { addons } from "storybook/manager-api";
+
+addons.setConfig({
+  toolbar: {
+    // Storybook 10.5.3's built-in zoom popover omits its upcoming required
+    // ariaLabel. Hide only that control until the upstream manager is fixed.
+    zoom: false,
+  },
+});

--- a/apps/storybook/.storybook/preview-head.html
+++ b/apps/storybook/.storybook/preview-head.html
@@ -4,21 +4,38 @@
    * while preparing userEvent. React Aria reads focus from the prototype when
    * Docs is first opened, which invokes that accessor with an invalid receiver.
    *
-   * Keep the native method writable for normal focus handling, but prevent the
-   * incompatible accessor replacement until Storybook fixes the initialization
-   * race.
+   * Make only that accessor safe when read from the prototype. Keep it
+   * configurable so userEvent can continue patching focus in interaction tests.
    */
   (() => {
-    const descriptor = Object.getOwnPropertyDescriptor(
-      HTMLElement.prototype,
-      focus,
-    );
+    const nativeFocus = HTMLElement.prototype.focus;
+    const nativeDefineProperties = Object.defineProperties;
 
-    if (descriptor?.configurable && value in descriptor) {
-      Object.defineProperty(HTMLElement.prototype, focus, {
-        ...descriptor,
-        configurable: false,
-      });
-    }
+    Object.defineProperties = (target, descriptors) => {
+      const focusDescriptor = descriptors.focus;
+
+      if (
+        target === HTMLElement.prototype &&
+        typeof focusDescriptor?.get === "function"
+      ) {
+        const storybookFocusGetter = focusDescriptor.get;
+
+        descriptors = {
+          ...descriptors,
+          focus: {
+            ...focusDescriptor,
+            get() {
+              return this === HTMLElement.prototype
+                ? nativeFocus
+                : storybookFocusGetter.call(this);
+            },
+          },
+        };
+
+        Object.defineProperties = nativeDefineProperties;
+      }
+
+      return nativeDefineProperties(target, descriptors);
+    };
   })();
 </script>

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "build:components": "turbo run build --filter=@repo/components",
     "build:hooks": "turbo run build --filter=@repo/hooks",
     "storybook": "pnpm --filter=storybook storybook",
+    "check-types:storybook": "pnpm build:hooks && pnpm --filter=storybook check-types",
+    "build:storybook": "turbo run build-storybook --filter=storybook",
     "test:storybook": "pnpm --filter=storybook test-storybook"
   },
   "devDependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -8,6 +8,10 @@
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "outputs": [".next/**", "!.next/cache/**", "dist/**"]
     },
+    "build-storybook": {
+      "dependsOn": ["^build"],
+      "outputs": ["storybook-static/**"]
+    },
     "lint": {
       "dependsOn": ["^lint"]
     },


### PR DESCRIPTION
## Summary

`main` 브랜치에 Storybook GitHub Pages 자동 배포가 이미 적용된 상태에서, 빌드/타입체크 스크립트를 turbo 태스크 기반으로 정리하고 PR 단위 CI 검증을 추가했습니다. 관련 문서와 Storybook 10.5.3의 알려진 버그 우회 처리도 함께 보완했습니다.

## Changes
- `package.json` / `turbo.json`: `check-types:storybook`, `build:storybook` 스크립트 추가, turbo `build-storybook` 태스크에 `dependsOn: ["^build"]` 지정으로 의존 패키지 빌드 자동화
- `.github/workflows/storybook_pages.yml`: 새 pnpm 스크립트를 사용하도록 변경 (수동 hooks 빌드 스텝 제거)
- `.github/workflows/storybook_ci.yml`: PR에서 Storybook 타입체크/빌드를 검증하는 CI 워크플로우 신규 추가
- `README.md`: Storybook 배포 배지, 기술 스택, "📚 Storybook" 섹션(제공 범위/실행 명령/배포 정보), 디렉토리 구조 업데이트
- `apps/storybook/.storybook/preview-head.html`: focus 접근자 우회 처리 개선 (userEvent의 focus patch를 계속 허용하면서 prototype 접근 시에만 안전하게 native focus 반환)
- `apps/storybook/.storybook/manager.ts`: zoom 팝오버의 ariaLabel 누락 버그로 인한 콘솔 경고를 막기 위해 zoom 툴바 버튼 숨김 처리

## Testing
- [ ] PR CI 워크플로우(`storybook_ci.yml`)가 정상적으로 트리거되고 통과하는지 확인
- [ ] Storybook 로컬 실행 시 focus/zoom 관련 콘솔 에러가 발생하지 않는지 확인
- [ ] GitHub Pages 배포 워크플로우가 변경된 스크립트로 정상 동작하는지 확인